### PR TITLE
CMS-317481 - Do not pass empty hooks or fields to resolveRelationship, pass undefined instead. This allows defaultHooks to run inside of Model.find

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - "6.11.1"
+  - "6.13.1"
   - "7.10.1"
-  - "8.2.1"
+  - "8.9.4"
+  - "9.9.0"
 services:
   - mongodb
 addons:

--- a/Model.js
+++ b/Model.js
@@ -349,13 +349,13 @@ Model.prototype.addRelationship = function(args) {
 		var hookArgs = extend(true, {}, args.hookArgs || {});
 		
 		// use the hookArgs fields, or cherry-pick the fields that apply to the relationship
-		newOptions.fields = hookArgs.fields !== undefined ? hookArgs.fields : mongolayer._getMyFields(objectKey, args.options.fields || {});
+		newOptions.fields = hookArgs.fields !== undefined ? hookArgs.fields : mongolayer._getMyFields(objectKey, args.options.fields);
 		// use the hookArgs hooks, or cherry-pick the hooks that apply to the relationship
-		newOptions.hooks = hookArgs.hooks !== undefined ? hookArgs.hooks : mongolayer._getMyHooks(objectKey, args.options.hooks || []);
+		newOptions.hooks = hookArgs.hooks !== undefined ? hookArgs.hooks : mongolayer._getMyHooks(objectKey, args.options.hooks);
 		// if we have fields, we pass mapDocs, it will take affect according to the state of castDocs
 		newOptions.mapDocs = hookArgs.fields !== undefined ? true : undefined;
 		newOptions.castDocs = hookArgs.castDocs !== undefined ? hookArgs.castDocs : args.options.castDocs;
-		
+
 		mongolayer.resolveRelationship({
 			type : type,
 			leftKey : leftKey,
@@ -367,8 +367,8 @@ Model.prototype.addRelationship = function(args) {
 			docs : args.docs,
 			mapDocs : newOptions.mapDocs,
 			castDocs : newOptions.castDocs,
-			hooks : newOptions.hooks,
-			fields : newOptions.fields
+			hooks : (newOptions.hooks.length > 0) ? newOptions.hooks : undefined,
+			fields : (Object.keys(newOptions.fields).length > 0) ? newOptions.fields : undefined
 		}, function(err, docs) {
 			if (err) { return cb(err); }
 			

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var mongodb = require("mongodb");
 var async = require("async");
 var extend = require("extend");
-var util = require("util");
 var typecaster = require("typecaster");
 
 var Connection = require("./Connection.js");
@@ -321,6 +320,8 @@ var _stringConvertV2_walk = function(dataObj, schemaObj) {
 
 // gets only hooks which apply to a specific model and de-namespaces them
 var _getMyHooks = function(myKey, hooks) {
+	if (hooks === undefined || hooks.length === 0) { return []; }
+
 	var myHooks = [];
 	var regMatch = new RegExp("^" + myKey + "\\..*");
 	var regReplace = new RegExp("^" + myKey + "\\.");
@@ -334,6 +335,8 @@ var _getMyHooks = function(myKey, hooks) {
 }
 
 var _getMyFields = function(myKey, fields) {
+	if (fields === undefined || Object.keys(fields).length === 0) { return {}; }
+
 	var myFields = {};
 	var regMatch = new RegExp("^" + myKey + "\\..*");
 	var regReplace = new RegExp("^" + myKey + "\\.");

--- a/package.json
+++ b/package.json
@@ -1,27 +1,29 @@
 {
-	"name" : "mongolayer",
-	"description" : "MongoDB model layer with validation and hooks, similar to Mongoose but thinner.",
-	"author" : "Owen Allen <owenallenaz@gmail.com>",
-	"version" : "1.4.4",
-	"devDependencies" : {
-		"mocha" : "*",
-		"request" : "*"
+	"name": "mongolayer",
+	"description": "MongoDB model layer with validation and hooks, similar to Mongoose but thinner.",
+	"author": "Owen Allen <owenallenaz@gmail.com>",
+	"version": "1.4.4",
+	"devDependencies": {
+		"mocha": "^5.0.5",
+		"request": "*"
 	},
-	"dependencies" : {
-		"async" : "*",
-		"extend" : "*",
-		"jsvalidator" : "*",
-		"mongodb" : "*",
-		"typecaster" : "*",
-		"simple-domain" : "*"
+	"dependencies": {
+		"async": "*",
+		"extend": "*",
+		"jsvalidator": "*",
+		"mongodb": "2.2",
+		"typecaster": "*",
+		"simple-domain": "*"
 	},
-	"engines" : { "node" : ">=0.10.x" },
-	"scripts" : {
-		"test" : "./node_modules/mocha/bin/mocha $(find testing/ -name *.test.js) -R spec --colors --check-leaks --globals Promise"
+	"engines": {
+		"node": ">=6.5.0"
 	},
-	"repository" : {
-		"type" : "git",
-		"url" : "https://github.com/simpleviewinc/mongolayer.git"
+	"scripts": {
+		"test": "./node_modules/mocha/bin/mocha $(find testing/ -name *.test.js) -R spec --colors --check-leaks --globals Promise"
 	},
-	"license" : "MIT"
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/simpleviewinc/mongolayer.git"
+	},
+	"license": "MIT"
 }

--- a/testing/index.test.js
+++ b/testing/index.test.js
@@ -367,10 +367,28 @@ describe(__filename, function() {
 	
 	it("should _getMyHooks", function(done) {
 		var test = mongolayer._getMyHooks("foo", [{ name : "nuts" }, { name : "foo" }, { name : "foo.bar" }, { name : "foo.bar.baz" }]);
+		assert.strictEqual(test.length, 2);
+		assert.strictEqual(test[0].name, "bar");
+		assert.strictEqual(test[1].name, "bar.baz");
+
+		var test = mongolayer._getMyHooks("foo", []);
+		assert.strictEqual(test.length, 0);
+
+		var test = mongolayer._getMyHooks("foo", undefined);
+		assert.strictEqual(test.length, 0);
 		
-		assert.equal(test.length, 2);
-		assert.equal(test[0].name, "bar");
-		assert.equal(test[1].name, "bar.baz");
+		done();
+	});
+
+	it("should _getMyFields", function(done) {
+		var test = mongolayer._getMyFields("foo", { "nuts" : 1, "foo" : 1, "foo.bar" : 1, "foo.bar.baz" : 1 });
+		assert.deepStrictEqual(test, { "bar" : 1, "bar.baz" : 1 });
+
+		var test = mongolayer._getMyFields("foo", {});
+		assert.deepStrictEqual(test, {});
+
+		var test = mongolayer._getMyFields("foo", undefined);
+		assert.deepStrictEqual(test, {});
 		
 		done();
 	});


### PR DESCRIPTION
Also removed util dependency from index.js and updated _getMyHooks and _getMyFields to return empty array/object early in the function if incoming argument is undefined/empty.