### PR TITLE
Cms 320549 upgrade mongolayer mongodb dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"async": "^2.6.2",
 		"extend": "^3.0.2",
 		"jsvalidator": "^1.2.0",
-		"mongodb": "^3.7.1",
+		"mongodb": "^3.7.4",
 		"p-memoize": "^3.1.0",
 		"typecaster": "^0.0.2"
 	},

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"async": "^2.6.2",
 		"extend": "^3.0.2",
 		"jsvalidator": "^1.2.0",
-		"mongodb": "^3.6.4",
+		"mongodb": "^3.7.1",
 		"p-memoize": "^3.1.0",
 		"typecaster": "^0.0.2"
 	},


### PR DESCRIPTION
This PR includes 2 commits:
1) updates mongolayer's mongodb dependency to version 3.7.1
2) updates mongolayer's mongodb dependency to version 3.7.4

The ticket called for updating to 3.7.1, but 3.7.4 is the latest 3.x.x release so it is included here. 

**Before changes were made, there was one unit test failing
![Screenshot 2023-11-30 000056](https://github.com/simpleviewinc/mongolayer/assets/9289544/b5ff27a3-18a4-47a7-87ad-695953a9d52b)

This test still fails and is not affected by work on this ticket.

In review, it was also noted that this repo has another pre-existing issue with critical dependency version issues relating to Mocha.