### PR TITLE
added support for SRV connection protocol

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ async function _connect(cached, args) {
 	const method = cached === true ? _getClientCached : _getClient;
 	
 	// parse the connectionString to detect a dbName
-	const parsed = args.connectionString.match(/mongodb:\/\/.*\/([^?]+)/);
+	const parsed = args.connectionString.match(/mongodb(?:\+srv)?:\/\/.*\/([^?]+)/);
 	if (parsed === null) {
 		throw new Error("You must specify a database in your connectionString.");
 	}


### PR DESCRIPTION
Tiny update to allow for connection strings that use the [SRV Connection Format](https://www.mongodb.com/docs/manual/reference/connection-string/#srv-connection-format)

Needed for cms-core ASAP.

FYI, I'm unable to get the docker container to build for running tests on either of my machines and don't have time to debug it just now. I've confirmed this update works with cms-core though, and it shouldn't affect any existing unit tests.