### PR TITLE
Update mongo version from 7 to 8 along with fcv as 7.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     depends_on:
       - "db"
   db:
-    image: mongo:7.0
+    image: mongo:8.0
     ports:
       - "13001:27017"
+    volumes:
+      - ./init-fcv.js:/docker-entrypoint-initdb.d/init-fcv.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,4 @@ services:
     ports:
       - "13001:27017"
     volumes:
-      - ./init-fcv.js:/docker-entrypoint-initdb.d/init-fcv.js
+      - ./init-fcv.js:/docker-entrypoint-initdb.d/init-fcv.js # used only this if we want to stick to a specific version of fcv

--- a/init-fcv.js
+++ b/init-fcv.js
@@ -1,0 +1,2 @@
+db = db.getSiblingDB("admin");
+db.adminCommand({ setFeatureCompatibilityVersion: "7.0", confirm: true });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"main": "src/index.js",
 	"engines": {
-		"node": ">=10.0.0"
+		"node": ">=16.20.1"
 	},
 	"scripts": {
 		"test": "mocha $(find testing/ -name *.test.js) -R spec --colors --check-leaks --globals Promise",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mongolayer",
 	"description": "MongoDB model layer with validation and hooks, similar to Mongoose but thinner.",
 	"author": "Owen Allen <owenallenaz@gmail.com>",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"devDependencies": {
 		"@simpleview/assertlib": "^1.0.1",
 		"@simpleview/mochalib": "^1.0.1",

--- a/src/Model.js
+++ b/src/Model.js
@@ -1335,7 +1335,7 @@ Model.prototype._validateDocData = function(data) {
 				return;
 			}
 			
-			if (val === null || val === undefined) {
+			if (val === null) {
 				// allow null to be saved to DB regardless of validation type
 				return;
 			}

--- a/src/Model.js
+++ b/src/Model.js
@@ -195,10 +195,6 @@ var Model = function(args) {
 // re-add all of the indexes to a model, useful if a collection needs to be dropped and re-built at run-time
 async function createIndexes() {
 	for (const index of this._indexes) {
-		// Remove background option if it exists
-        // if (index.options && index.options.background) {
-        //     delete index.options.background;
-        // }
 		await this.collection.createIndex(index.keys, index.options);
 	}
 }

--- a/src/Model.js
+++ b/src/Model.js
@@ -195,6 +195,10 @@ var Model = function(args) {
 // re-add all of the indexes to a model, useful if a collection needs to be dropped and re-built at run-time
 async function createIndexes() {
 	for (const index of this._indexes) {
+		// Remove background option if it exists
+        // if (index.options && index.options.background) {
+        //     delete index.options.background;
+        // }
 		await this.collection.createIndex(index.keys, index.options);
 	}
 }
@@ -1335,7 +1339,7 @@ Model.prototype._validateDocData = function(data) {
 				return;
 			}
 			
-			if (val === null) {
+			if (val === null || val === undefined) {
 				// allow null to be saved to DB regardless of validation type
 				return;
 			}


### PR DESCRIPTION
### **Major Change**
Version Upgrade: MongoDB 7 → 8

### **Context**
This PR upgrades the environment and dependencies to ensure full compatibility with MongoDB v8, addressing engine, driver, and feature compatibility requirements.

### **Summary of changes**

_**1) Node Engine Update**_
Reason: MongoDB v8 requires Node.js v16+.
Change: Updated package.json to specify engines.node >= 16.
Previous Minimum: Node.js v10

**_2) MongoDB Driver Compatibility_**
The mongodb driver v6.15.0 used in mongo-layer is confirmed to be compatible with MongoDB v8 and FCV 7.

**_3) Deprecation Handling_**
No deprecations or breaking changes found.

**_4) FCV Management_**
Since mongo-layer relies on a MongoDB Docker image, the FCV was already set to 7.
To ensure FCV remains 7 after upgrading to MongoDB v8, a volume mount was added in docker-compose for explicit FCV configuration.

**_5) Testing & Validation_**
Environment: MongoDB v8, FCV 7
Outcome: All existing unit tests passed successfully.
Verification: No regression or query behavior issues observed.

**_6) Version Upgrade_**
Updated mongolayer to v4.0 to reflect compatibility and environment upgrade.